### PR TITLE
DEMO: Markdown warnings that DocC wouldn’t report

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ Available versions include:
 ## Install
 
 ### Desktop browser
-
 Drag the desired bookmark to the bookmark bar or add bookmark/favorite.
 Optionally edit or rename the bookmark/favorite.
 
 + `fyi-webkit` --
   <a href="javascript:%28%28%29%3D%3E%7Blet%20o%3D%27user%40domain.tld%27%2Ce%3D%27%27%3Bconst%20n%3DencodeURIComponent%28document.title%29%2Ct%3D%27%250D%250A%27%2Cd%3Dwindow.getSelection%28%29%3B%27%27%3D%3D%3De%26%26%28e%3Dwindow.prompt%28%27Send%20link%20to%20email%20address%28es%29%3A%27%2Co%29%29%3B%27%27%21%3D%3De%26%26%28location.href%3D%60mailto%3A%24%7Be%7D%3Fsubject%3Dfyi%3A%24%7Bn%7D%26body%3D%24%7Bn%7D%24%7Bt%7D%24%7BencodeURIComponent%28location.href%29%7D%24%7Bt%7D---%24%7Bt%7D%24%7BencodeURIComponent%28d%29%7D%24%7Bt%7D%24%7Bt%7D%60%29%7D%29%28%29%3Bvoid%272.9.2wk%27"
   title="fyi-webkit">fyi</a>
+* Next item with a different style of bullet list indicator
+
+Sample Markdown link without URL that causes an error [Link to nowhere]().
 
 ## Usage
 


### PR DESCRIPTION
The Markdown lint utility should find issues in the Markdown and warn me about them, even though I could do a push to my branch to get this far.

However, a local git hook script `.git/hooks/pre-push` could run Markdown lint to warn me about the issues and even block the push to the repo until I fix it.

If I really needed to push anyway, I could do a `git push --force` on the command line.

I'd like to investigate using git hooks _with_ **Xcode** built-in Source Control to see what one can do with things like `pre-commit` and `pre-push`. AND how we can see message or do over-rides.

Also, I'd like to investigate how one might use GitHub Actions with GitHub Enterprise Server.
